### PR TITLE
TETO-91 BugFix: 어드민페이지 UI 밀린 버그 수정

### DIFF
--- a/frontend/admin/src/components/MainContent.css
+++ b/frontend/admin/src/components/MainContent.css
@@ -64,4 +64,36 @@
     background: linear-gradient(135deg, #a8edea 0%, #fed6e3 100%);
     color: #333;
 }
+.tab-content {
+  display: block !important;
+  min-height: auto !important;
+}
 
+.tab-pane {
+  display: none !important;
+  opacity: 0;
+  transition: opacity 0.15s ease-in-out;
+  padding-top: 0 !important;
+  margin-top: 0 !important;
+}
+
+.tab-pane.active.show {
+  display: block !important;
+  opacity: 1;
+}
+
+.selected-restaurant-badge {
+  background: #e9f5ff;
+  color: #0d6efd;
+  border: 1px solid #b6d8ff;
+  padding: 6px 14px;
+  border-radius: 20px;
+  font-size: 0.9rem;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.selected-restaurant-badge i {
+  color: #0d6efd;
+}

--- a/frontend/admin/src/components/MainContent.jsx
+++ b/frontend/admin/src/components/MainContent.jsx
@@ -1,4 +1,4 @@
-import { useState, useCallback } from "react";
+import { useState, useEffect } from "react";
 import './MainContent.css';
 import './Waiting.css';
 
@@ -15,19 +15,42 @@ import WaitingTab from './tabs/WaitingTab';
 
 export default function MainContent() {
   const [activeTab, setActiveTab] = useState("dashboard");
-
   const [selectedRestaurant, setSelectedRestaurant] = useState(null);
+
+  // ✅ 기존 클릭 이벤트 (직접 클릭 시에도 초기화)
   const handleTabClick = (e) => {
     const href = e.target.getAttribute("href");
     if (href === "#restaurant-info") {
-      setSelectedRestaurant(null); // 등록 탭이면 수정 상태 초기화
+      setSelectedRestaurant(null);
     }
   };
+
+  // ✅ 추가: Bootstrap 탭 전환 감지 (Tab.show()로 전환될 때도 초기화되게)
+  useEffect(() => {
+    const tabElements = document.querySelectorAll('a[data-bs-toggle="tab"]');
+
+    const handleShown = (event) => {
+      const target = event.target.getAttribute("href");
+      if (target === "#restaurant-info") {
+        setSelectedRestaurant(null); // 탭 전환 시에도 선택 초기화
+      }
+    };
+
+    tabElements.forEach((tab) =>
+      tab.addEventListener("shown.bs.tab", handleShown)
+    );
+
+    return () => {
+      tabElements.forEach((tab) =>
+        tab.removeEventListener("shown.bs.tab", handleShown)
+      );
+    };
+  }, []);
 
   return (
     <div className="col-md-9 col-lg-10">
       <div className="main-content" onClick={handleTabClick}>
-        {/* Header Section */}
+        {/* ✅ Header Section */}
         <div className="header-section">
           <div className="container-fluid">
             <div className="d-flex justify-content-between align-items-center">
@@ -35,11 +58,24 @@ export default function MainContent() {
                 <h2 className="mb-0">매장 관리</h2>
                 <p className="text-muted mb-0">정미스시 매장 정보를 관리하세요</p>
               </div>
+
+              {/* ✅ 현재 선택된 매장 표시 */}
+              {selectedRestaurant ? (
+                <div className="selected-restaurant-badge">
+                  <i className="fas fa-store me-2 text-primary"></i>
+                  <strong>{selectedRestaurant.name}</strong>
+                </div>
+              ) : (
+                <div className="text-muted small">
+                  <i className="fas fa-info-circle me-1"></i>
+                  선택된 매장이 없습니다
+                </div>
+              )}
             </div>
           </div>
         </div>
 
-        {/* 탭별 내용 */}
+        {/* ✅ 탭별 내용 */}
         <div className="container-fluid">
           <div className="tab-content">
             <DashboardTab />
@@ -59,7 +95,6 @@ export default function MainContent() {
             <ImagesTab />
             <ReviewsTab />
             <WaitingTab />
-            {/* <Test /> */}
           </div>
         </div>
       </div>

--- a/frontend/admin/src/components/Sidebar.css
+++ b/frontend/admin/src/components/Sidebar.css
@@ -14,8 +14,3 @@
             background: #495057;
             color: white;
         }
-
-        /* Sidebar.css */
-        .sidebar a[href="#menu-management"] {
-            display: none !important;
-        }

--- a/frontend/admin/src/components/tabs/MenuManagementTab.jsx
+++ b/frontend/admin/src/components/tabs/MenuManagementTab.jsx
@@ -79,12 +79,12 @@ export default function MenuManagementTab({ selectedRestaurant }) {
       className="tab-pane fade"
       id="menu-management"
       style={{
-        height: "100%",
+        minHeight: "calc(100vh - 150px)",
         background: "#f8f9fa",
-        display: "flex",
-        flexDirection: "column",
-        justifyContent: "space-between",
-        overflow: "hidden",
+        display: "block",
+        overflowY: "auto",
+        boxSizing: "border-box",
+        padding: "20px"
       }}
     >
       {/* 헤더 */}


### PR DESCRIPTION
## 🔗 관련 이슈
- 없음 (UI 정렬 관련 버그 수정)

## 📝 작업 내용
- 어드민 페이지 탭 전환 시 UI 밀림 현상 수정  
- `tab-pane` 여백 및 정렬 문제 해결  
- 매장 목록/등록 탭 디자인 통일

## 🔍 변경 이유
- 일관된 화면 정렬 유지 필요

## 💬 리뷰 포인트
- 모든 탭 전환 시 화면이 정상적으로 정렬되는지 확인  
- 기존 스타일이나 기능에 영향이 없는지 체크
