### PR TITLE
TETO-92 Feature 어드민에서 웨이팅 취소 시 사용자 화면에도 웨이팅 숫자 자동 동기화

### DIFF
--- a/backend/realtime-service/src/main/java/com/tabletopia/realtimeservice/domain/waiting/controller/WaitingController.java
+++ b/backend/realtime-service/src/main/java/com/tabletopia/realtimeservice/domain/waiting/controller/WaitingController.java
@@ -8,6 +8,7 @@ import com.tabletopia.realtimeservice.domain.waiting.enums.WaitingState;
 import com.tabletopia.realtimeservice.domain.waiting.repository.WaitingRepository;
 import com.tabletopia.realtimeservice.domain.waiting.service.WaitingService;
 import jakarta.ws.rs.Path;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -158,6 +159,8 @@ public class WaitingController {
   public ResponseEntity<String>cancelWaiting(@PathVariable Long id, @RequestParam Long restaurantId) {
 
     waitingService.cancelWaiting(id, restaurantId);
+    simpMessagingTemplate.convertAndSend("/topic/cancel",
+        Map.of("type", "CANCEL","id", id, "restaurantId", restaurantId,"timestamp", LocalDateTime.now()));
 
     return ResponseEntity.ok("웨이팅이 취소되었습니다.");
   }

--- a/frontend/admin/src/components/tabs/WaitingTab.jsx
+++ b/frontend/admin/src/components/tabs/WaitingTab.jsx
@@ -152,6 +152,14 @@ export default function WaitingTab() {
           }
         });
 
+        //웨이팅 취소 구독
+        client.subscribe('/topic/cancel', (msg) => {
+          const alert = JSON.parse(msg.body);
+          if(alert.type === "CANCEL") {
+            fetchWaitingList();
+          }
+        });
+
       },
 
       onStompError: (frame) => {

--- a/frontend/user/src/pages/restaurant/Waiting.jsx
+++ b/frontend/user/src/pages/restaurant/Waiting.jsx
@@ -87,6 +87,14 @@ export default function Waiting() {
           }
         });
 
+         //웨이팅 취소 구독
+        client.subscribe('/topic/cancel', (msg) => {
+          const alert = JSON.parse(msg.body);
+          if(alert.type === "CANCEL") {
+            fetchWaitingList();
+          }
+        });
+
 
         //웨이팅 등록 구독
         const subscription = client.subscribe('/topic/regist', (msg) => {


### PR DESCRIPTION
<!-- 
제목 양식
Jira-키 커밋타입: 제목
ex, PROJ-3 Feature: JWT 기반 사용자 인증 시스템 구현
-->

## 🔗 관련 이슈
<!-- 연결된 깃허브 이슈 번호 작성 -->
#19 

## 📝 작업 내용
<!-- 이번 PR에서 구현/수정한 기능을 간단히 작성 -->
어드민에서 웨이팅 취소할 때 사용자 화면에 웨이팅 숫자 자동으로 변경되게 수정

## 🔍 변경 이유
<!-- 왜 이 변경이 필요한지 간단히 작성 -->
사용자화면을 새로고침해야 웨이팅 현황이 변경되는 불편함이 있어서 자동으로 바뀔 수 있게 수정

## 💬 리뷰 포인트
<!-- 리뷰어가 집중해서 확인해야 할 사항 -->
어드민 측에서 웨이팅 취소 후 사용자 측에 웨이팅 현황 자동으로 변경되는지 확인
