### PR TITLE
TETO-98 Frontend: 매장 선택안했을시 UI 수정

### DIFF
--- a/frontend/admin/src/components/tabs/FacilitiesTab.jsx
+++ b/frontend/admin/src/components/tabs/FacilitiesTab.jsx
@@ -1,12 +1,50 @@
-export default function FacilitiesTab(){
-  const facilities = [
-    {icon:"fa-car", name:"발렛파킹", desc:"무료 발렛파킹 서비스 제공"},
-    {icon:"fa-wheelchair", name:"휠체어 접근", desc:"휠체어 이용 가능"},
-    {icon:"fa-wine-glass-alt", name:"주류 판매", desc:"다양한 주류 판매"},
-    {icon:"fa-wifi", name:"무료 WiFi", desc:"고속 무료 인터넷"},
-    {icon:"fa-birthday-cake", name:"기념일 서비스", desc:"생일, 기념일 케이크 서비스"},
-    {icon:"fa-users", name:"단체석", desc:"10인 이상 단체 이용 가능"},
-  ]
+import { useEffect, useState } from "react";
+import axios from "axios";
+
+export default function FacilitiesTab({ selectedRestaurant }) {
+  const [facilities, setFacilities] = useState([]);
+  const [checkedFacilities, setCheckedFacilities] = useState({});
+
+  useEffect(() => {
+    if (!selectedRestaurant) return;
+    loadFacilities();
+  }, [selectedRestaurant]);
+
+  const loadFacilities = async () => {
+    const [allRes, assignedRes] = await Promise.all([
+      axios.get("http://localhost:10022/api/facilities"),
+      axios.get(`http://localhost:10022/api/facilities/${selectedRestaurant.id}`)
+    ]);
+    setFacilities(allRes.data);
+    const assigned = {};
+    assignedRes.data.forEach(f => assigned[f.id] = true);
+    setCheckedFacilities(assigned);
+  };
+
+  const toggleFacility = async (facilityId) => {
+    const isChecked = !checkedFacilities[facilityId];
+    setCheckedFacilities(prev => ({ ...prev, [facilityId]: isChecked }));
+    if (isChecked) {
+      await axios.post(`http://localhost:10022/api/facilities/${selectedRestaurant.id}`, { facilityId });
+    } else {
+      await axios.delete(`http://localhost:10022/api/facilities/${selectedRestaurant.id}/${facilityId}`);
+    }
+  };
+
+  if (!selectedRestaurant) {
+    return (
+      <div className="tab-pane fade" id="facilities">
+        <div className="card text-center mt-4 border-danger">
+          <div className="card-body py-5">
+            <i className="fas fa-store-slash fa-3x text-danger mb-3"></i>
+            <h5 className="text-danger fw-bold">매장이 선택되지 않았습니다</h5>
+            <p className="text-muted mb-0">편의시설을 관리하려면 먼저 매장을 선택해주세요.</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
   return (
     <div className="tab-pane fade" id="facilities">
       <div className="card">
@@ -14,24 +52,31 @@ export default function FacilitiesTab(){
           <i className="fas fa-cogs me-2"></i>편의시설 관리
         </div>
         <div className="card-body">
-          <div className="row">
-            {facilities.map(f=>(
-              <div key={f.name} className="col-md-4 mb-3">
-                <div className="card text-center">
-                  <div className="card-body">
-                    <i className={`fas ${f.icon} fa-3x text-primary mb-3`}></i>
+          {facilities.length === 0 ? (
+            <p className="text-center text-muted mt-3">등록된 편의시설이 없습니다.</p>
+          ) : (
+            <div className="row">
+              {facilities.map(f => (
+                <div key={f.id} className="col-md-3 mb-3">
+                  <div className="card text-center p-2">
+                    <img src={f.iconUrl} alt={f.name} width={48} height={48} className="mx-auto mb-2" />
                     <h6>{f.name}</h6>
                     <div className="form-check form-switch d-flex justify-content-center">
-                      <input className="form-check-input" type="checkbox" defaultChecked/>
+                      <input
+                        className="form-check-input"
+                        type="checkbox"
+                        checked={!!checkedFacilities[f.id]}
+                        onChange={() => toggleFacility(f.id)}
+                      />
                     </div>
-                    <small className="text-muted">{f.desc}</small>
+                    <small className="text-muted">{f.info || ""}</small>
                   </div>
                 </div>
-              </div>
-            ))}
-          </div>
+              ))}
+            </div>
+          )}
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/frontend/admin/src/components/tabs/MenuManagementTab.jsx
+++ b/frontend/admin/src/components/tabs/MenuManagementTab.jsx
@@ -79,7 +79,13 @@ export default function MenuManagementTab({ selectedRestaurant }) {
   if (!selectedRestaurant) {
     return (
       <div className="tab-pane fade" id="menu-management">
-        <p className="text-center mt-3 text-muted">먼저 매장을 선택해주세요.</p>
+        <div className="card text-center mt-4 border-danger">
+          <div className="card-body py-5">
+            <i className="fas fa-store-slash fa-3x text-danger mb-3"></i>
+            <h5 className="text-danger fw-bold">매장이 선택되지 않았습니다</h5>
+            <p className="text-muted mb-0">메뉴를 관리하려면 먼저 매장을 선택해주세요.</p>
+          </div>
+        </div>
       </div>
     );
   }

--- a/frontend/admin/src/components/tabs/OperatingHoursTab.jsx
+++ b/frontend/admin/src/components/tabs/OperatingHoursTab.jsx
@@ -127,7 +127,13 @@ export default function OperatingHoursTab({ selectedRestaurant }) {
   if (!selectedRestaurant) {
     return (
       <div className="tab-pane fade" id="operating-hours">
-        <p className="text-center mt-3 text-muted">먼저 매장을 선택해주세요.</p>
+        <div className="card text-center mt-4 border-danger">
+          <div className="card-body py-5">
+            <i className="fas fa-store-slash fa-3x text-danger mb-3"></i>
+            <h5 className="text-danger fw-bold">매장이 선택되지 않았습니다</h5>
+            <p className="text-muted mb-0">영업시간을 설정하려면 먼저 매장을 선택해주세요.</p>
+          </div>
+        </div>
       </div>
     );
   }

--- a/frontend/admin/src/components/tabs/SpecialHoursTab.jsx
+++ b/frontend/admin/src/components/tabs/SpecialHoursTab.jsx
@@ -95,7 +95,7 @@ export default function SpecialHoursTab({ selectedRestaurant }) {
     }
   };
 
-  // ✅ 페이징 계산
+
   const totalPages = Math.ceil(specialHours.length / itemsPerPage);
   const currentItems = specialHours.slice(
     (currentPage - 1) * itemsPerPage,
@@ -103,11 +103,18 @@ export default function SpecialHoursTab({ selectedRestaurant }) {
   );
 
   if (!selectedRestaurant)
-    return (
-      <div className="tab-pane fade" id="special-hours">
-        <p className="text-center mt-3 text-muted">먼저 매장을 선택해주세요.</p>
+  return (
+    <div className="tab-pane fade" id="special-hours">
+      <div className="card text-center mt-4 border-danger">
+        <div className="card-body py-5">
+          <i className="fas fa-store-slash fa-3x text-danger mb-3"></i>
+          <h5 className="text-danger fw-bold">매장이 선택되지 않았습니다</h5>
+          <p className="text-muted mb-0">특별 운영시간을 관리하려면 먼저 매장을 선택해주세요.</p>
+        </div>
       </div>
-    );
+    </div>
+  );
+
 
   return (
     <div className="tab-pane fade" id="special-hours">


### PR DESCRIPTION
## 🔗 관련 이슈
TETO-98

## 📝 작업 내용
- 매장 미선택 시 각 탭(운영시간, 메뉴관리, 편의시설, 특별운영시간 등)에 공통 안내 UI 추가  
- 매장이 선택되지 않았을 때 붉은색 카드 형태의 안내 문구가 표시되도록 수정  
- 탭별 문구 및 id 속성(operating-hours, menu-management 등) 일관성 정리  
- 탭별 안내 문구가 해당 기능 맥락에 맞도록 수정 (예: "운영시간을 설정하려면 먼저 매장을 선택해주세요")

## 🔍 변경 이유
- 매장이 선택되지 않았을 때 화면이 비어 있거나 혼동을 주는 문제 개선  
- 사용자에게 명확한 피드백 제공 및 UI 일관성 확보

## 💬 리뷰 포인트
- 각 탭에서 매장 미선택 시 안내 카드가 정상적으로 표시되는지  
- 탭 전환 시 UI 깜빡임이나 active 상태 이상이 없는지  
- 문구 및 색상 스타일이 전체 관리자 페이지와 통일되어 있는지
