### PR TITLE
TETO-104 Feature: 어드민페이지 편의시설관리

### DIFF
--- a/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/facility/controller/FacilityController.java
+++ b/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/facility/controller/FacilityController.java
@@ -9,8 +9,14 @@ import java.util.List;
 /**
  * 편의시설 관련 요청을 처리하는 컨트롤러
  *
+ * 공통 마스터 테이블인 Facility 데이터를 조회하는 기능을 제공한다.
+ * 프론트엔드에서는 매장 등록 또는 수정 시
+ * 선택 가능한 편의시설 목록을 불러올 때 사용한다.
+ *
+ * - GET /api/facilities : 전체 편의시설 목록 조회
+ *
  * @author 김지민
- * @since 2025-10-13
+ * @since 2025-10-14
  */
 @RestController
 @RequestMapping("/api/facilities")
@@ -25,7 +31,7 @@ public class FacilityController {
   /**
    * 전체 편의시설 목록 조회
    *
-   * @return 편의시설 응답 DTO 리스트
+   * @return 편의시설 목록 DTO 리스트
    */
   @GetMapping
   public ResponseEntity<List<FacilityResponse>> getAllFacilities() {

--- a/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/facility/dto/FacilityResponse.java
+++ b/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/facility/dto/FacilityResponse.java
@@ -7,14 +7,26 @@ import lombok.NoArgsConstructor;
 /**
  * 편의시설 정보를 응답 형태로 전달하기 위한 DTO
  *
+ * Facility 엔티티의 주요 속성(id, name)만을 포함하며,
+ * 클라이언트에 표시할 수 있는 단순한 형태의 데이터를 제공한다.
+ *
+ * 예:
+ * {
+ *   "id": 1,
+ *   "name": "Wi-Fi"
+ * }
+ *
  * @author 김지민
- * @since 2025-10-13
+ * @since 2025-10-14
  */
 @Getter
 @NoArgsConstructor
-public class FacilityResponse{
+public class FacilityResponse {
 
+  /** 편의시설 ID */
   private Long id;
+
+  /** 편의시설 이름 */
   private String name;
 
   /**

--- a/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/facility/entity/Facility.java
+++ b/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/facility/entity/Facility.java
@@ -1,30 +1,40 @@
 package com.tabletopia.restaurantservice.domain.facility.entity;
 
 import jakarta.persistence.*;
-import lombok.Getter;
-import lombok.Setter;
-import java.time.LocalDateTime;
+import lombok.*;
 
-// 편의시설 마스터 테이블
+/**
+ * 편의시설 마스터 엔티티
+ *
+ * 매장에서 공통적으로 사용하는 편의시설(Facility) 정보를 정의한다.
+ * 예: Wi-Fi, 주차 가능, 반려동물 동반 가능 등
+ *
+ * 단순 마스터 테이블로, 별도의 생성일/수정일 컬럼은 관리하지 않는다.
+ *
+ * DB 스키마:
+ *  - facility (
+ *        id BIGINT AUTO_INCREMENT PRIMARY KEY,
+ *        name VARCHAR(50) NOT NULL UNIQUE
+ *    )
+ *
+ * @author 김지민
+ * @since 2025-10-14
+ */
 @Entity
 @Table(name = "facility")
 @Getter
 @Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
 public class Facility {
 
+  /** 고유 식별자 (PK) */
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
-  // 시설 이름
+  /** 시설 이름 (예: Wi-Fi, 주차 가능 등) */
   @Column(nullable = false, unique = true, length = 50)
   private String name;
-
-  // 생성 일시
-  @Column(name = "created_at", updatable = false)
-  private LocalDateTime createdAt;
-
-  // 수정 일시
-  @Column(name = "updated_at")
-  private LocalDateTime updatedAt;
 }

--- a/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/facility/repository/FacilityRepository.java
+++ b/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/facility/repository/FacilityRepository.java
@@ -7,8 +7,11 @@ import org.springframework.stereotype.Repository;
 /**
  * 편의시설 마스터 데이터에 접근하는 레포지토리
  *
+ * Facility 엔티티에 대한 기본 CRUD 기능을 제공한다.
+ * 추가적인 쿼리 메서드는 필요 시 정의한다.
+ *
  * @author 김지민
- * @since 2025-10-13
+ * @since 2025-10-14
  */
 @Repository
 public interface FacilityRepository extends JpaRepository<Facility, Long> {

--- a/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/facility/service/FacilityService.java
+++ b/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/facility/service/FacilityService.java
@@ -1,7 +1,6 @@
 package com.tabletopia.restaurantservice.domain.facility.service;
 
 import com.tabletopia.restaurantservice.domain.facility.dto.FacilityResponse;
-import com.tabletopia.restaurantservice.domain.facility.entity.Facility;
 import com.tabletopia.restaurantservice.domain.facility.repository.FacilityRepository;
 import org.springframework.stereotype.Service;
 import java.util.List;
@@ -9,8 +8,11 @@ import java.util.List;
 /**
  * 편의시설 관련 비즈니스 로직을 처리하는 서비스 클래스
  *
+ * Facility 마스터 테이블에 대한 조회 로직을 담당하며,
+ * 모든 시설 목록을 클라이언트에 전달 가능한 DTO 형태로 변환한다.
+ *
  * @author 김지민
- * @since 2025-10-13
+ * @since 2025-10-14
  */
 @Service
 public class FacilityService {
@@ -24,11 +26,10 @@ public class FacilityService {
   /**
    * 전체 편의시설 목록 조회
    *
-   * @return FacilityResponseDto 리스트
+   * @return FacilityResponse DTO 리스트
    */
   public List<FacilityResponse> getAllFacilities() {
-    List<Facility> facilities = facilityRepository.findAll();
-    return facilities.stream()
+    return facilityRepository.findAll().stream()
         .map(FacilityResponse::new)
         .toList();
   }

--- a/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurantFacility/controller/RestaurantFacilityController.java
+++ b/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurantFacility/controller/RestaurantFacilityController.java
@@ -10,8 +10,17 @@ import java.util.Map;
 /**
  * 매장별 편의시설 관련 요청을 처리하는 컨트롤러
  *
+ * 매장(Restaurant)에 연결된 편의시설(Facility)을
+ * 조회, 추가, 삭제하는 기능을 제공한다.
+ *
+ * - GET /api/facilities/{restaurantId} : 매장의 시설 목록 조회
+ * - POST /api/facilities/{restaurantId} : 매장에 시설 추가
+ * - DELETE /api/facilities/{restaurantId}/{facilityId} : 매장에서 시설 제거
+ *
+ * DB 스키마는 restaurant_facility 중간 테이블을 기준으로 한다.
+ *
  * @author 김지민
- * @since 2025-10-13
+ * @since 2025-10-14
  */
 @RestController
 @RequestMapping("/api/facilities")
@@ -40,7 +49,7 @@ public class RestaurantFacilityController {
    *
    * @param restaurantId 매장 ID
    * @param request facilityId 포함 요청 바디
-   * @return 성공 응답
+   * @return 성공 시 200 OK
    */
   @PostMapping("/{restaurantId}")
   public ResponseEntity<Void> addFacility(
@@ -57,7 +66,7 @@ public class RestaurantFacilityController {
    *
    * @param restaurantId 매장 ID
    * @param facilityId 시설 ID
-   * @return 성공 시 204 응답
+   * @return 성공 시 204 No Content
    */
   @DeleteMapping("/{restaurantId}/{facilityId}")
   public ResponseEntity<Void> removeFacility(

--- a/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurantFacility/dto/RestaurantFacilityResponse.java
+++ b/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurantFacility/dto/RestaurantFacilityResponse.java
@@ -5,19 +5,23 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 /**
- * 매장별 편의시설 정보를 응답 형태로 전달하기 위한 DTO
+ * 매장별 편의시설 정보를 클라이언트에 전달하기 위한 DTO
+ *
+ * 매장(Restaurant)에 연결된 편의시설(Facility)의 기본 정보만 포함한다.
+ * 활성화 여부(isActive) 등의 상태는 포함하지 않는다.
  *
  * @author 김지민
- * @since 2025-10-13
+ * @since 2025-10-14
  */
 @Getter
 @NoArgsConstructor
-public class RestaurantFacilityResponse{
+public class RestaurantFacilityResponse {
 
+  /** 편의시설 ID */
   private Long facilityId;
+
+  /** 편의시설 이름 */
   private String facilityName;
-  private String facilityInfo;
-  private boolean active;
 
   /**
    * 엔티티를 DTO로 변환하는 생성자
@@ -27,7 +31,5 @@ public class RestaurantFacilityResponse{
   public RestaurantFacilityResponse(RestaurantFacility entity) {
     this.facilityId = entity.getFacility().getId();
     this.facilityName = entity.getFacility().getName();
-    this.facilityInfo = entity.getFacilityInfo();
-    this.active = entity.isActive();
   }
 }

--- a/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurantFacility/entity/RestaurantFacility.java
+++ b/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurantFacility/entity/RestaurantFacility.java
@@ -7,14 +7,36 @@ import lombok.*;
 import java.time.LocalDateTime;
 
 /**
+ * 매장별 편의시설 매핑 엔티티
+ *
+ * 매장(Restaurant)과 편의시설(Facility) 간의 다대다 관계를 표현하는 중간 엔티티.
+ * 매장 삭제 시 관련 편의시설 매핑도 함께 삭제된다 (ON DELETE CASCADE).
+ *
+ * createdAt, updatedAt은 엔티티 저장 및 수정 시 자동으로 설정된다.
+ *
+ * DB 스키마 예시:
+ *  - restaurant_facility (
+ *        id BIGINT AUTO_INCREMENT PRIMARY KEY,
+ *        restaurant_id BIGINT NOT NULL,
+ *        facility_id BIGINT NOT NULL,
+ *        created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+ *        updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+ *        UNIQUE KEY (restaurant_id, facility_id)
+ *    )
+ *
  * @author 김지민
  * @since 2025-10-14
- * @description 레스토랑-편의시설 매핑 엔티티
- * 매장에 어떤 편의시설이 활성화되어 있는지 관리한다.
- * created_at, updated_at 은 엔티티 저장 시 자동으로 설정된다.
  */
 @Entity
-@Table(name = "restaurant_facility")
+@Table(
+    name = "restaurant_facility",
+    uniqueConstraints = {
+        @UniqueConstraint(
+            name = "uk_restaurant_facility",
+            columnNames = {"restaurant_id", "facility_id"}
+        )
+    }
+)
 @Getter
 @Setter
 @NoArgsConstructor
@@ -22,36 +44,37 @@ import java.time.LocalDateTime;
 @Builder
 public class RestaurantFacility {
 
+  /** 고유 식별자 (PK) */
   @Id
   @GeneratedValue(strategy = GenerationType.IDENTITY)
   private Long id;
 
+  /** 매장 정보 (N:1 관계) */
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "restaurant_id", nullable = false)
   private Restaurant restaurant;
 
+  /** 편의시설 정보 (N:1 관계) */
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "facility_id", nullable = false)
   private Facility facility;
 
-  @Column(name = "facility_info")
-  private String facilityInfo;
-
-  @Column(name = "is_active", nullable = false)
-  private boolean isActive = true;
-
+  /** 생성 일시 */
   @Column(name = "created_at", nullable = false, updatable = false)
   private LocalDateTime createdAt;
 
+  /** 수정 일시 */
   @Column(name = "updated_at", nullable = false)
   private LocalDateTime updatedAt;
 
+  /** 최초 저장 시 자동 설정 */
   @PrePersist
   protected void onCreate() {
     this.createdAt = LocalDateTime.now();
     this.updatedAt = LocalDateTime.now();
   }
 
+  /** 수정 시 자동 갱신 */
   @PreUpdate
   protected void onUpdate() {
     this.updatedAt = LocalDateTime.now();

--- a/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurantFacility/repository/RestaurantFacilityRepository.java
+++ b/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurantFacility/repository/RestaurantFacilityRepository.java
@@ -8,14 +8,28 @@ import java.util.List;
 /**
  * 매장별 편의시설 데이터 접근 레포지토리
  *
+ * RestaurantFacility 엔티티에 대한 기본 CRUD 및
+ * 매장별 시설 조회, 특정 시설 삭제 기능을 제공한다.
+ *
  * @author 김지민
- * @since 2025-10-13
+ * @since 2025-10-14
  */
 @Repository
 public interface RestaurantFacilityRepository extends JpaRepository<RestaurantFacility, Long> {
 
+  /**
+   * 특정 매장의 모든 편의시설 조회
+   *
+   * @param restaurantId 매장 ID
+   * @return 매장에 연결된 편의시설 리스트
+   */
   List<RestaurantFacility> findByRestaurantId(Long restaurantId);
 
+  /**
+   * 매장에서 특정 시설 삭제
+   *
+   * @param restaurantId 매장 ID
+   * @param facilityId 시설 ID
+   */
   void deleteByRestaurantIdAndFacilityId(Long restaurantId, Long facilityId);
-
 }

--- a/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurantFacility/service/RestaurantFacilityService.java
+++ b/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurantFacility/service/RestaurantFacilityService.java
@@ -14,8 +14,16 @@ import java.util.List;
 /**
  * 매장별 편의시설 관련 비즈니스 로직을 처리하는 서비스 클래스
  *
+ * 주요 기능:
+ * - 특정 매장의 편의시설 목록 조회
+ * - 매장에 새 시설 추가
+ * - 매장에서 시설 제거
+ *
+ * 매장(Restaurant)과 편의시설(Facility) 간의 중간 테이블을 관리한다.
+ * 별도의 활성/비활성 상태(isActive)는 없으며, 단순 추가/삭제로만 관리한다.
+ *
  * @author 김지민
- * @since 2025-10-13
+ * @since 2025-10-14
  */
 @Service
 public class RestaurantFacilityService {
@@ -38,7 +46,7 @@ public class RestaurantFacilityService {
    * 특정 매장의 편의시설 목록 조회
    *
    * @param restaurantId 매장 ID
-   * @return 매장의 편의시설 DTO 리스트
+   * @return 매장에 등록된 편의시설 목록 DTO
    */
   public List<RestaurantFacilityResponse> getFacilitiesByRestaurant(Long restaurantId) {
     List<RestaurantFacility> list = restaurantFacilityRepository.findByRestaurantId(restaurantId);
@@ -48,7 +56,7 @@ public class RestaurantFacilityService {
   }
 
   /**
-   * 매장에 시설 추가
+   * 매장에 새로운 시설 추가
    *
    * @param restaurantId 매장 ID
    * @param facilityId 시설 ID
@@ -60,6 +68,14 @@ public class RestaurantFacilityService {
     Facility facility = facilityRepository.findById(facilityId)
         .orElseThrow(() -> new IllegalArgumentException("해당 시설을 찾을 수 없습니다."));
 
+    // 중복 등록 방지
+    boolean exists = restaurantFacilityRepository.findByRestaurantId(restaurantId).stream()
+        .anyMatch(rf -> rf.getFacility().getId().equals(facilityId));
+
+    if (exists) {
+      throw new IllegalStateException("이미 등록된 시설입니다.");
+    }
+
     RestaurantFacility entity = new RestaurantFacility();
     entity.setRestaurant(restaurant);
     entity.setFacility(facility);
@@ -67,7 +83,7 @@ public class RestaurantFacilityService {
   }
 
   /**
-   * 매장에서 시설 삭제
+   * 매장에서 특정 시설 삭제
    *
    * @param restaurantId 매장 ID
    * @param facilityId 시설 ID

--- a/frontend/admin/package-lock.json
+++ b/frontend/admin/package-lock.json
@@ -8,10 +8,11 @@
       "name": "admin",
       "version": "0.0.0",
       "dependencies": {
-        "@fortawesome/fontawesome-free": "^7.0.1",
+        "@fortawesome/fontawesome-free": "^7.1.0",
         "@stomp/stompjs": "^7.2.0",
         "axios": "^1.12.2",
         "bootstrap": "^5.3.0",
+        "bootstrap-icons": "^1.13.1",
         "date-fns": "^4.1.0",
         "jwt-decode": "^4.0.0",
         "react": "^19.2.0",
@@ -1634,6 +1635,22 @@
       "peerDependencies": {
         "@popperjs/core": "^2.11.8"
       }
+    },
+    "node_modules/bootstrap-icons": {
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/bootstrap-icons/-/bootstrap-icons-1.13.1.tgz",
+      "integrity": "sha512-ijombt4v6bv5CLeXvRWKy7CuM3TRTuPEuGaGKvTV5cz65rQSY8RQ2JcHt6b90cBBAC7s8fsf2EkQDldzCoXUjw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/twbs"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/bootstrap"
+        }
+      ],
+      "license": "MIT"
     },
     "node_modules/brace-expansion": {
       "version": "1.1.12",

--- a/frontend/admin/package.json
+++ b/frontend/admin/package.json
@@ -10,10 +10,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
-    "@fortawesome/fontawesome-free": "^7.0.1",
+    "@fortawesome/fontawesome-free": "^7.1.0",
     "@stomp/stompjs": "^7.2.0",
     "axios": "^1.12.2",
     "bootstrap": "^5.3.0",
+    "bootstrap-icons": "^1.13.1",
     "date-fns": "^4.1.0",
     "jwt-decode": "^4.0.0",
     "react": "^19.2.0",

--- a/frontend/admin/src/components/tabs/FacilitiesTab.jsx
+++ b/frontend/admin/src/components/tabs/FacilitiesTab.jsx
@@ -1,9 +1,43 @@
 import { useEffect, useState } from "react";
 import axios from "axios";
+import "@fortawesome/fontawesome-free/css/all.min.css";
 
 export default function FacilitiesTab({ selectedRestaurant }) {
   const [facilities, setFacilities] = useState([]);
   const [checkedFacilities, setCheckedFacilities] = useState({});
+
+  const getFacilityIcon = (name) => {
+    switch (name) {
+      case "Wi-Fi":
+        return "fa-solid fa-wifi";
+      case "금연":
+        return "fa-solid fa-ban-smoking";
+      case "흡연실":
+        return "fa-solid fa-smoking";
+      case "단체석":
+        return "fa-solid fa-people-group";
+      case "반려동물 동반 가능":
+        return "fa-solid fa-dog";
+      case "장애인 편의시설":
+        return "fa-solid fa-wheelchair";
+      case "주차 가능":
+        return "fa-solid fa-car";
+      case "키즈존":
+        return "fa-solid fa-child-reaching";
+      case "테라스":
+        return "fa-solid fa-sun";
+      case "화장실":
+        return "fa-solid fa-restroom";
+      case "포장 가능":
+        return "fa-solid fa-box";
+      case "배달 가능":
+        return "fa-solid fa-motorcycle";
+      case "노키즈존":
+        return "fa-solid fa-ban";
+      default:
+        return "fa-solid fa-gear";
+    }
+  };
 
   useEffect(() => {
     if (!selectedRestaurant) return;
@@ -11,26 +45,47 @@ export default function FacilitiesTab({ selectedRestaurant }) {
   }, [selectedRestaurant]);
 
   const loadFacilities = async () => {
-    const [allRes, assignedRes] = await Promise.all([
-      axios.get("http://localhost:8002/api/facilities"),
-      axios.get(`http://localhost:8002/api/facilities/${selectedRestaurant.id}`)
-    ]);
+    try {
+      const [allRes, assignedRes] = await Promise.all([
+        axios.get("http://localhost:8002/api/facilities"),
+        axios.get(
+          `http://localhost:8002/api/facilities/${selectedRestaurant.id}`
+        ),
+      ]);
 
-    setFacilities(allRes.data);
+      setFacilities(allRes.data);
 
-    const assigned = {};
-    assignedRes.data.forEach(f => assigned[f.facilityId] = true);
-    setCheckedFacilities(assigned);
+      const assigned = {};
+      assignedRes.data.forEach((f) => (assigned[f.facilityId] = true));
+      setCheckedFacilities(assigned);
+    } catch (error) {
+      console.error("시설 목록 로드 실패:", error);
+      alert("시설 목록을 불러오는 중 오류가 발생했습니다.");
+    }
   };
 
   const toggleFacility = async (facilityId) => {
     const isChecked = !checkedFacilities[facilityId];
-    setCheckedFacilities(prev => ({ ...prev, [facilityId]: isChecked }));
+    setCheckedFacilities((prev) => ({ ...prev, [facilityId]: isChecked }));
 
-    if (isChecked) {
-      await axios.post(`http://localhost:8002/api/facilities/${selectedRestaurant.id}`, { facilityId });
-    } else {
-      await axios.delete(`http://localhost:8002/api/facilities/${selectedRestaurant.id}/${facilityId}`);
+    try {
+      if (isChecked) {
+        await axios.post(
+          `http://localhost:8002/api/facilities/${selectedRestaurant.id}`,
+          { facilityId }
+        );
+      } else {
+        await axios.delete(
+          `http://localhost:8002/api/facilities/${selectedRestaurant.id}/${facilityId}`
+        );
+      }
+    } catch (error) {
+      console.error("편의시설 업데이트 실패:", error);
+      alert("편의시설 변경 중 오류가 발생했습니다.");
+      setCheckedFacilities((prev) => ({
+        ...prev,
+        [facilityId]: !isChecked,
+      }));
     }
   };
 
@@ -41,7 +96,9 @@ export default function FacilitiesTab({ selectedRestaurant }) {
           <div className="card-body py-5">
             <i className="fas fa-store-slash fa-3x text-danger mb-3"></i>
             <h5 className="text-danger fw-bold">매장이 선택되지 않았습니다</h5>
-            <p className="text-muted mb-0">편의시설을 관리하려면 먼저 매장을 선택해주세요.</p>
+            <p className="text-muted mb-0">
+              편의시설을 관리하려면 먼저 매장을 선택해주세요.
+            </p>
           </div>
         </div>
       </div>
@@ -51,19 +108,25 @@ export default function FacilitiesTab({ selectedRestaurant }) {
   return (
     <div className="tab-pane fade" id="facilities">
       <div className="card">
-        <div className="card-header">
-          <i className="fas fa-cogs me-2"></i>편의시설 관리
+        <div className="card-header bg-primary text-white fw-bold">
+          <i className="fa-solid fa-gear me-2"></i>편의시설 관리
         </div>
         <div className="card-body">
           {facilities.length === 0 ? (
-            <p className="text-center text-muted mt-3">등록된 편의시설이 없습니다.</p>
+            <p className="text-center text-muted mt-3">
+              등록된 편의시설이 없습니다.
+            </p>
           ) : (
             <div className="row">
-              {facilities.map(f => (
-                <div key={f.id} className="col-md-3 mb-3">
-                  <div className="card text-center p-2">
-                    <i className="fas fa-check-circle fa-2x text-primary mb-2"></i>
-                    <h6>{f.name}</h6>
+              {facilities.map((f) => (
+                <div key={f.id} className="col-sm-6 col-md-3 mb-3">
+                  <div className="card text-center p-3 shadow-sm h-100">
+                    <i
+                      className={`${getFacilityIcon(
+                        f.name
+                      )} fs-2 text-primary mb-2`}
+                    ></i>
+                    <h6 className="mb-2">{f.name}</h6>
                     <div className="form-check form-switch d-flex justify-content-center">
                       <input
                         className="form-check-input"

--- a/frontend/admin/src/main.jsx
+++ b/frontend/admin/src/main.jsx
@@ -2,6 +2,7 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App.jsx";
 import "bootstrap/dist/css/bootstrap.min.css";
+import "@fortawesome/fontawesome-free/css/all.min.css";
 import "bootstrap/dist/js/bootstrap.bundle.min.js"; 
 import "./index.css";
 


### PR DESCRIPTION
# 🏷️ TETO-104 Feature: 어드민페이지 편의시설관리

## 🔗 관련 이슈
- Jira: [TETO-104]
---

## 📝 작업 내용
- 어드민 페이지 내 **편의시설 관리 탭(FacilitiesTab)** 구현  
- FontAwesome 기반 아이콘 시스템 적용 (`fa-solid` 시리즈)  
- 시설별 활성/비활성 스위치 기능 추가 (POST / DELETE API 연동)  
- 매장 미선택 시 안내 카드 및 아이콘 표시 추가 (`fa-store-slash`)  

---

## 🔍 변경 이유
- 기존에는 어드민이 매장별 편의시설을 직접 관리할 수 있는 UI가 없었음  
- 각 매장의 시설 상태(활성/비활성)를 웹에서 즉시 조정할 수 있도록 개선  
- 사용자 경험(UX) 향상을 위해 직관적인 아이콘 및 스위치 토글 UI 도입  

---

## 💬 리뷰 포인트
- [ ] 매장 선택/미선택 시 조건부 렌더링 동작 확인  
- [ ] 반응형 UI 레이아웃(2~4열)이 화면 크기에 맞게 동작하는지  


[TETO-104]: https://tabletopiaproject.atlassian.net/browse/TETO-104?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ