### PR TITLE
TETO-105 Feature: 이미지 등록 및 관리

### DIFF
--- a/backend/restaurant-service/build.gradle
+++ b/backend/restaurant-service/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.5.6' // 최신 유지
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'org.jetbrains.kotlin.jvm'
 }
 
 group = 'com.tabletopia'
@@ -65,6 +66,7 @@ dependencies {
 
     //페이징
     implementation 'org.modelmapper:modelmapper:3.1.1'
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
 }
 
 dependencyManagement {

--- a/backend/restaurant-service/settings.gradle
+++ b/backend/restaurant-service/settings.gradle
@@ -1,1 +1,6 @@
+pluginManagement {
+    plugins {
+        id 'org.jetbrains.kotlin.jvm' version '2.2.0'
+    }
+}
 rootProject.name = 'restaurant-service'

--- a/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurantImage/controller/RestaurantImageController.java
+++ b/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurantImage/controller/RestaurantImageController.java
@@ -1,0 +1,84 @@
+package com.tabletopia.restaurantservice.domain.restaurantImage.controller;
+
+import com.tabletopia.restaurantservice.domain.restaurantImage.dto.RestaurantImageResponse;
+import com.tabletopia.restaurantservice.domain.restaurantImage.service.RestaurantImageService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+import java.util.List;
+
+/**
+ * 매장 이미지 관련 요청을 처리하는 컨트롤러
+ *
+ * 매장(Restaurant)에 등록된 이미지(RestaurantImage)를
+ * 조회, 업로드, 대표 설정, 삭제하는 기능을 제공한다.
+ *
+ * - GET /api/images/{restaurantId} : 매장의 이미지 목록 조회
+ * - POST /api/images/{restaurantId} : 이미지 업로드
+ * - PUT /api/images/main/{imageId} : 대표 이미지 설정
+ * - DELETE /api/images/{imageId} : 이미지 삭제
+ *
+ * DB 스키마는 restaurant_image 테이블을 기준으로 한다.
+ *
+ * @author 김지민
+ * @since 2025-10-15
+ */
+@RestController
+@RequestMapping("/api/images")
+@RequiredArgsConstructor
+public class RestaurantImageController {
+
+  private final RestaurantImageService imageService;
+
+  /**
+   * 특정 매장의 이미지 목록 조회
+   *
+   * @param restaurantId 매장 ID
+   * @return 매장에 등록된 이미지 DTO 리스트
+   */
+  @GetMapping("/{restaurantId}")
+  public ResponseEntity<List<RestaurantImageResponse>> getImages(@PathVariable Long restaurantId) {
+    return ResponseEntity.ok(imageService.getImages(restaurantId));
+  }
+
+  /**
+   * 매장에 이미지 업로드
+   *
+   * @param restaurantId 매장 ID
+   * @param files 업로드할 이미지 파일 목록
+   * @return 성공 시 200 OK
+   */
+  @PostMapping("/{restaurantId}")
+  public ResponseEntity<Void> uploadImages(
+      @PathVariable Long restaurantId,
+      @RequestParam("files") List<MultipartFile> files
+  ) {
+    imageService.uploadImages(restaurantId, files);
+    return ResponseEntity.ok().build();
+  }
+
+  /**
+   * 특정 이미지를 대표 이미지로 설정
+   *
+   * @param imageId 이미지 ID
+   * @return 성공 시 200 OK
+   */
+  @PutMapping("/main/{imageId}")
+  public ResponseEntity<Void> setMainImage(@PathVariable Long imageId) {
+    imageService.setMainImage(imageId);
+    return ResponseEntity.ok().build();
+  }
+
+  /**
+   * 특정 이미지를 삭제
+   *
+   * @param imageId 이미지 ID
+   * @return 성공 시 204 No Content
+   */
+  @DeleteMapping("/{imageId}")
+  public ResponseEntity<Void> deleteImage(@PathVariable Long imageId) {
+    imageService.deleteImage(imageId);
+    return ResponseEntity.noContent().build();
+  }
+}

--- a/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurantImage/dto/RestaurantImageResponse.java
+++ b/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurantImage/dto/RestaurantImageResponse.java
@@ -1,0 +1,34 @@
+package com.tabletopia.restaurantservice.domain.restaurantImage.dto;
+
+import com.tabletopia.restaurantservice.domain.restaurantImage.entity.RestaurantImage;
+import lombok.*;
+
+/**
+ * 매장 이미지 조회 응답 DTO
+ *
+ * 매장 이미지 정보 반환용 데이터 전송 객체.
+ * 이미지 ID, URL, 대표 여부, 정렬 순서를 포함한다.
+ *
+ * @author 김지민
+ * @since 2025-10-15
+ */
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RestaurantImageResponse {
+  private Long id;
+  private String imageUrl;
+  private boolean isMain;
+  private int sortOrder;
+
+  public static RestaurantImageResponse from(RestaurantImage entity) {
+    return RestaurantImageResponse.builder()
+        .id(entity.getId())
+        .imageUrl("/uploads/restaurants/" + entity.getImageUrl()) // URL 조합
+        .isMain(entity.isMain())
+        .sortOrder(entity.getSortOrder())
+        .build();
+  }
+}

--- a/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurantImage/entity/RestaurantImage.java
+++ b/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurantImage/entity/RestaurantImage.java
@@ -1,0 +1,61 @@
+package com.tabletopia.restaurantservice.domain.restaurantImage.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import java.time.LocalDateTime;
+import com.tabletopia.restaurantservice.domain.restaurant.entity.Restaurant;
+
+/**
+ * 매장 이미지 엔티티
+ *
+ * 매장(Restaurant)에 연결된 이미지 정보를 관리한다.
+ * 각 이미지에는 대표 여부, 정렬 순서 등의 메타데이터가 포함된다.
+ *
+ * DB 스키마는 restaurant_image 테이블을 기준으로 한다.
+ *
+ * @author 김지민
+ * @since 2025-10-15
+ */
+@Entity
+@Table(name = "restaurant_image")
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RestaurantImage {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "restaurant_id", nullable = false)
+  private Restaurant restaurant;
+
+  @Column(name = "image_url", nullable = false, length = 255)
+  private String imageUrl;
+
+  @Column(name = "is_main", nullable = false)
+  private boolean isMain = false;
+
+  @Column(name = "sort_order", nullable = false)
+  private int sortOrder = 0;
+
+  @Column(name = "created_at", nullable = false)
+  private LocalDateTime createdAt = LocalDateTime.now();
+
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt = LocalDateTime.now();
+
+  @PrePersist
+  public void prePersist() {
+    this.createdAt = this.createdAt == null ? LocalDateTime.now() : this.createdAt;
+    this.updatedAt = this.updatedAt == null ? LocalDateTime.now() : this.updatedAt;
+  }
+
+  @PreUpdate
+  public void preUpdate() {
+    this.updatedAt = LocalDateTime.now();
+  }
+}

--- a/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurantImage/repository/RestaurantImageRepository.java
+++ b/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurantImage/repository/RestaurantImageRepository.java
@@ -1,0 +1,17 @@
+package com.tabletopia.restaurantservice.domain.restaurantImage.repository;
+
+import com.tabletopia.restaurantservice.domain.restaurantImage.entity.RestaurantImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+/**
+ * 매장 이미지 관련 데이터베이스 접근 레포지토리
+ *
+ * 매장별 이미지 목록 조회 및 CRUD 연산을 처리한다.
+ *
+ * @author 김지민
+ * @since 2025-10-15
+ */
+public interface RestaurantImageRepository extends JpaRepository<RestaurantImage, Long> {
+  List<RestaurantImage> findByRestaurantIdOrderBySortOrderAsc(Long restaurantId);
+}

--- a/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurantImage/service/RestaurantImageService.java
+++ b/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurantImage/service/RestaurantImageService.java
@@ -1,0 +1,103 @@
+package com.tabletopia.restaurantservice.domain.restaurantImage.service;
+
+import com.tabletopia.restaurantservice.domain.restaurant.entity.Restaurant;
+import com.tabletopia.restaurantservice.domain.restaurant.repository.RestaurantRepository;
+import com.tabletopia.restaurantservice.domain.restaurantImage.entity.RestaurantImage;
+import com.tabletopia.restaurantservice.domain.restaurantImage.dto.RestaurantImageResponse;
+import com.tabletopia.restaurantservice.domain.restaurantImage.repository.RestaurantImageRepository;
+import com.tabletopia.restaurantservice.util.FileStorageService;
+import java.nio.file.Paths;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/**
+ * 매장 이미지 관련 비즈니스 로직을 처리하는 서비스 클래스
+ *
+ * 매장별 이미지 조회, 업로드, 대표 이미지 지정, 삭제 기능을 제공한다.
+ * 업로드 시 FileStorageService를 이용해 로컬 디렉토리에 파일을 저장한다.
+ *
+ * @author 김지민
+ * @since 2025-10-15
+ */
+@Service
+@RequiredArgsConstructor
+public class RestaurantImageService {
+
+  private final RestaurantImageRepository imageRepository;
+  private final RestaurantRepository restaurantRepository;
+  private final FileStorageService fileStorageService;
+
+  /**
+   * 특정 매장의 이미지 목록 조회
+   *
+   * @param restaurantId 매장 ID
+   * @return 이미지 DTO 리스트
+   */
+  public List<RestaurantImageResponse> getImages(Long restaurantId) {
+    return imageRepository.findByRestaurantIdOrderBySortOrderAsc(restaurantId)
+        .stream()
+        .map(img -> RestaurantImageResponse.builder()
+            .id(img.getId())
+            .imageUrl(img.getImageUrl())
+            .isMain(img.isMain())
+            .sortOrder(img.getSortOrder())
+            .build())
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * 매장에 이미지 업로드
+   *
+   * @param restaurantId 매장 ID
+   * @param files 업로드할 이미지 파일 목록
+   */
+  public void uploadImages(Long restaurantId, List<MultipartFile> files) {
+    Restaurant restaurant = restaurantRepository.findById(restaurantId)
+        .orElseThrow(() -> new IllegalArgumentException("매장 정보를 찾을 수 없습니다."));
+
+    for (MultipartFile file : files) {
+      String savedFileName = fileStorageService.save(file, "restaurants");
+
+      // DB에는 파일명만 저장
+      String fileNameOnly = Paths.get(savedFileName).getFileName().toString();
+
+      RestaurantImage img = RestaurantImage.builder()
+          .restaurant(restaurant)
+          .imageUrl(fileNameOnly) // ← 파일명만 저장
+          .build();
+
+      imageRepository.save(img);
+    }
+  }
+
+  /**
+   * 특정 이미지를 대표 이미지로 지정
+   *
+   * @param imageId 대표로 지정할 이미지 ID
+   */
+  public void setMainImage(Long imageId) {
+    RestaurantImage target = imageRepository.findById(imageId)
+        .orElseThrow(() -> new IllegalArgumentException("이미지를 찾을 수 없습니다."));
+
+    List<RestaurantImage> images = imageRepository.findByRestaurantIdOrderBySortOrderAsc(
+        target.getRestaurant().getId()
+    );
+
+    for (RestaurantImage img : images) {
+      img.setMain(img.getId().equals(imageId));
+      imageRepository.save(img);
+    }
+  }
+
+  /**
+   * 특정 이미지를 삭제
+   *
+   * @param imageId 삭제할 이미지 ID
+   */
+  public void deleteImage(Long imageId) {
+    imageRepository.deleteById(imageId);
+  }
+}

--- a/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/util/FileStorageService.java
+++ b/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/util/FileStorageService.java
@@ -21,13 +21,14 @@ public class FileStorageService {
   @Value("${app.upload-dir}")
   private String uploadDir;
 
-  public String save(MultipartFile file) {
+  public String save(MultipartFile file, String subDir) {
     try {
       String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
-      Path filePath = Paths.get(uploadDir, fileName);
-      Files.createDirectories(filePath.getParent());
+      Path dirPath = Paths.get(uploadDir, subDir);
+      Files.createDirectories(dirPath);
+      Path filePath = dirPath.resolve(fileName);
       file.transferTo(filePath.toFile());
-      return fileName;
+      return "/uploads/" + subDir + "/" + fileName;
     } catch (IOException e) {
       throw new RuntimeException("파일 저장 실패: " + e.getMessage(), e);
     }

--- a/frontend/admin/src/components/tabs/ImagesTab.jsx
+++ b/frontend/admin/src/components/tabs/ImagesTab.jsx
@@ -1,37 +1,233 @@
-export default function ImagesTab(){
-  return (
-    <div className="tab-pane fade" id="images">
-      <div className="card">
-        <div className="card-header">
-          <i className="fas fa-images me-2"></i>매장 이미지 관리
-        </div>
-        <div className="card-body">
-          <div className="image-upload-area mb-4 text-center">
-            <i className="fas fa-cloud-upload-alt fa-3x text-muted mb-3"></i>
-            <h5>이미지 업로드</h5>
-            <p className="text-muted">클릭하거나 파일을 드래그하여 업로드하세요</p>
-            <button className="btn btn-outline-primary">파일 선택</button>
-            <input type="file" className="d-none" multiple accept="image/*"/>
-          </div>
-          <h6>현재 업로드된 이미지</h6>
-          <div className="row">
-            {[1,2,3,4].map((id)=>(
-              <div key={id} className="col-md-3 mb-3">
-                <div className="card">
-                  <img src="https://placehold.co/300x200/9ACD32/ffffff?text=Img" 
-                       className="card-img-top" alt="매장 이미지"/>
-                  <div className="card-body text-center p-2">
-                    <div className="btn-group btn-group-sm">
-                      <button className="btn btn-outline-primary">대표</button>
-                      <button className="btn btn-outline-danger">삭제</button>
-                    </div>
-                  </div>
-                </div>
-              </div>
-            ))}
+import { useEffect, useState, useRef } from "react"
+import axios from "axios"
+
+export default function ImagesTab({ selectedRestaurant }) {
+  const [images, setImages] = useState([])
+  const [currentPage, setCurrentPage] = useState(1)
+  const [loading, setLoading] = useState(false)
+  const itemsPerPage = 8
+  const fileInputRef = useRef()
+
+  useEffect(() => {
+    if (selectedRestaurant) {
+      loadImages()
+    } else {
+      setImages([])
+    }
+  }, [selectedRestaurant])
+
+  const loadImages = async () => {
+    if (!selectedRestaurant) return
+    setLoading(true)
+    try {
+      const res = await axios.get(`http://localhost:8002/api/images/${selectedRestaurant.id}`)
+      setImages(res.data)
+    } catch (err) {
+      console.error("이미지 목록 로드 실패:", err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const uploadFiles = async (files) => {
+    if (!files || files.length === 0) return
+    const formData = new FormData()
+    for (let file of files) formData.append("files", file)
+    try {
+      setLoading(true)
+      await axios.post(`http://localhost:8002/api/images/${selectedRestaurant.id}`, formData, {
+        headers: { "Content-Type": "multipart/form-data" },
+      })
+      await loadImages()
+    } catch (err) {
+      console.error("이미지 업로드 실패:", err)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleFileChange = (e) => uploadFiles(e.target.files)
+
+  const handleSetMain = async (id) => {
+    try {
+      await axios.put(`http://localhost:8002/api/images/main/${id}`)
+      loadImages()
+    } catch (err) {
+      console.error("대표 이미지 설정 실패:", err)
+    }
+  }
+
+  const handleDelete = async (id) => {
+    if (!window.confirm("정말 삭제하시겠습니까?")) return
+    try {
+      await axios.delete(`http://localhost:8002/api/images/${id}`)
+      loadImages()
+    } catch (err) {
+      console.error("이미지 삭제 실패:", err)
+    }
+  }
+
+  if (!selectedRestaurant) {
+    return (
+      <div className="tab-pane fade" id="images">
+        <div className="card text-center mt-4 border-danger">
+          <div className="card-body py-5">
+            <i className="fas fa-store-slash fa-3x text-danger mb-3"></i>
+            <h5 className="text-danger fw-bold">매장이 선택되지 않았습니다</h5>
+            <p className="text-muted mb-0">이미지를 관리하려면 먼저 매장을 선택해주세요.</p>
           </div>
         </div>
       </div>
+    )
+  }
+
+  const totalPages = Math.ceil(images.length / itemsPerPage)
+  const startIndex = (currentPage - 1) * itemsPerPage
+  const currentImages = images.slice(startIndex, startIndex + itemsPerPage)
+
+  return (
+    <div
+      className="tab-pane fade"
+      id="images"
+      style={{
+        minHeight: "calc(100vh - 150px)",
+        background: "#f8f9fa",
+        display: "block",
+        padding: "20px",
+      }}
+    >
+      <div
+        className="d-flex justify-content-between align-items-center"
+        style={{ padding: "10px 20px 0" }}
+      >
+        <h4 className="m-0">{selectedRestaurant.name} 이미지 관리</h4>
+        <button className="btn btn-primary" onClick={() => fileInputRef.current.click()}>
+          <i className="fas fa-plus me-1"></i> 이미지 추가
+        </button>
+        <input
+          ref={fileInputRef}
+          type="file"
+          className="d-none"
+          multiple
+          accept="image/*"
+          onChange={handleFileChange}
+        />
+      </div>
+
+      <div
+        className="image-upload-area text-center mt-3 p-3 border border-2 border-secondary-subtle rounded"
+        style={{
+          cursor: "pointer",
+          background: "#fff",
+          maxWidth: "500px",
+          margin: "20px auto",
+          transition: "background 0.2s, border-color 0.2s",
+        }}
+        onClick={() => fileInputRef.current.click()}
+        onDragOver={(e) => {
+          e.preventDefault()
+          e.currentTarget.style.background = "#e9f7ef"
+          e.currentTarget.style.borderColor = "#28a745"
+        }}
+        onDragLeave={(e) => {
+          e.currentTarget.style.background = "#fff"
+          e.currentTarget.style.borderColor = "#dee2e6"
+        }}
+        onDrop={(e) => {
+          e.preventDefault()
+          e.currentTarget.style.background = "#fff"
+          e.currentTarget.style.borderColor = "#dee2e6"
+          uploadFiles(e.dataTransfer.files)
+        }}
+      >
+        <i className="fas fa-cloud-upload-alt fa-2x text-muted mb-2"></i>
+        <h6 className="fw-bold">이미지 업로드</h6>
+        <p className="text-muted small mb-0">클릭하거나 파일을 드래그하여 업로드하세요</p>
+      </div>
+
+      {loading ? (
+        <div className="text-center mt-5">
+          <div className="spinner-border text-primary" role="status"></div>
+          <p className="mt-2 text-muted">로딩 중...</p>
+        </div>
+      ) : (
+        <>
+          <div
+            className="image-grid"
+            style={{
+              display: "grid",
+              gridTemplateColumns: "repeat(4, 1fr)",
+              gap: "16px",
+              padding: "10px 30px 0",
+            }}
+          >
+            {currentImages.length === 0 ? (
+              <p className="text-center text-muted mt-3">등록된 이미지가 없습니다.</p>
+            ) : (
+              currentImages.map((img) => (
+                <div key={img.id} className="card shadow-sm">
+                  <img
+                    src={`http://localhost:8002/uploads/restaurants/${img.imageUrl}`}
+                    alt="매장 이미지"
+                    className="card-img-top"
+                    style={{ height: "150px", objectFit: "cover" }}
+                  />
+                  <div className="card-body text-center p-2">
+                    <div className="btn-group btn-group-sm">
+                      <button
+                        className={`btn ${img.isMain ? "btn-primary" : "btn-outline-primary"}`}
+                        onClick={() => handleSetMain(img.id)}
+                      >
+                        대표
+                      </button>
+                      <button
+                        className="btn btn-outline-danger"
+                        onClick={() => handleDelete(img.id)}
+                      >
+                        삭제
+                      </button>
+                    </div>
+                    {img.isMain && <span className="badge bg-primary mt-2">대표 이미지</span>}
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+
+          <nav className="mt-3">
+            <ul className="pagination justify-content-center">
+              <li className={`page-item ${currentPage === 1 ? "disabled" : ""}`}>
+                <button className="page-link" onClick={() => setCurrentPage(currentPage - 1)}>
+                  &lsaquo;
+                </button>
+              </li>
+
+              {Array.from({ length: totalPages }, (_, i) => i + 1)
+                .filter((page) => {
+                  const groupStart = Math.floor((currentPage - 1) / 5) * 5 + 1
+                  const groupEnd = groupStart + 4
+                  return page >= groupStart && page <= groupEnd
+                })
+                .map((page) => (
+                  <li
+                    key={page}
+                    className={`page-item ${page === currentPage ? "active" : ""}`}
+                  >
+                    <button className="page-link" onClick={() => setCurrentPage(page)}>
+                      {page}
+                    </button>
+                  </li>
+                ))}
+
+              <li className={`page-item ${currentPage === totalPages ? "disabled" : ""}`}>
+                <button className="page-link" onClick={() => setCurrentPage(currentPage + 1)}>
+                  &rsaquo;
+                </button>
+              </li>
+            </ul>
+          </nav>
+        </>
+      )}
     </div>
   )
 }

--- a/frontend/admin/src/components/tabs/RestaurantListTab.jsx
+++ b/frontend/admin/src/components/tabs/RestaurantListTab.jsx
@@ -79,6 +79,7 @@ export default function RestaurantListTab({ onEdit, onSelectRestaurant, selected
   const totalPages = Math.ceil(restaurants.length / itemsPerPage);
   const startIndex = (currentPage - 1) * itemsPerPage;
   const currentItems = restaurants.slice(startIndex, startIndex + itemsPerPage);
+  console.log(currentItems);
 
   console.log("currentItems: " +currentItems);
 


### PR DESCRIPTION
## 🔗 관련 이슈
- TETO-105

## 📝 작업 내용
- 레스토랑 이미지 등록 및 관리 탭(ImagesTab) 구현
- 이미지 목록 조회, 업로드, 삭제, 대표 이미지 설정 기능 추가
- 클릭 및 드래그 앤 드롭(Drag & Drop) 업로드 지원
- 업로드 중 로딩 스피너 표시 추가

## 🔍 변경 이유
- 레스토랑별 이미지 데이터를 효율적으로 관리하기 위함
- 사용자가 직관적으로 이미지를 추가, 수정, 삭제할 수 있도록 개선
- 관리자가 대표 이미지를 쉽게 지정할 수 있도록 기능 확장

## 💬 리뷰 포인트
- 드래그 앤 드롭 업로드 동작이 정상적으로 수행되는지
- 업로드/삭제 후 이미지 목록이 즉시 갱신되는지
- 페이지네이션 동작 및 이미지 표시 개수(8장)가 적절한지

