### PR TITLE
TETO-97 BugFix: 상세페이지 휴무일 관련 버그 수정

### DIFF
--- a/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurant/entity/Restaurant.java
+++ b/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurant/entity/Restaurant.java
@@ -1,6 +1,7 @@
 package com.tabletopia.restaurantservice.domain.restaurant.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.tabletopia.restaurantservice.domain.restaurantAccount.entity.RestaurantAccount;
 import com.tabletopia.restaurantservice.domain.restaurantCategory.entity.RestaurantCategory;
 import com.tabletopia.restaurantservice.domain.restaurantFacility.entity.RestaurantFacility;
 import com.tabletopia.restaurantservice.domain.restaurantImage.entity.RestaurantImage;
@@ -114,8 +115,8 @@ public class Restaurant {
   private List<RestaurantImage> restaurantImage = new ArrayList<>();
 
   /** 매장 소유 계정 (FK) */
-//  @ManyToOne(fetch = FetchType.LAZY)
-//  @JoinColumn(name = "restaurant_account_id", nullable = false)
-//  @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
-//  private RestaurantAccount restaurantAccount;
+  @ManyToOne(fetch = FetchType.LAZY)
+  @JoinColumn(name = "restaurant_account_id", nullable = false)
+  @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+  private RestaurantAccount restaurantAccount;
 }

--- a/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurantAccount/entity/RestaurantAccount.java
+++ b/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurantAccount/entity/RestaurantAccount.java
@@ -1,0 +1,37 @@
+package com.tabletopia.restaurantservice.domain.restaurantAccount.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "restaurant_account")
+@EntityListeners(AuditingEntityListener.class)
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class RestaurantAccount {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  private Long id;
+
+  @Column(nullable = false, length = 100)
+  private String email;
+
+  @Column(nullable = false, length = 255)
+  private String password;
+
+  @CreatedDate
+  @Column(name = "created_at", nullable = false, updatable = false)
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(name = "updated_at", nullable = false)
+  private LocalDateTime updatedAt;
+}

--- a/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurantSpecialHour/service/RestaurantSpecialHourService.java
+++ b/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurantSpecialHour/service/RestaurantSpecialHourService.java
@@ -39,10 +39,15 @@ public class RestaurantSpecialHourService {
   private final RestaurantRepository restaurantRepository;
 
   /** 매장의 특별 운영시간 전체 조회 */
-  @Transactional(readOnly = true)
   public List<RestaurantSpecialHourResponse> getSpecialHours(Long restaurantId) {
     return specialHourRepository.findByRestaurantId(restaurantId).stream()
         .map(RestaurantSpecialHourResponse::fromEntity)
+        .peek(dto -> {
+          if (Boolean.TRUE.equals(dto.getIsClosed())) {
+            dto.setOpenTime(null);
+            dto.setCloseTime(null);
+          }
+        })
         .collect(Collectors.toList());
   }
 

--- a/frontend/admin/src/components/tabs/SpecialHoursTab.jsx
+++ b/frontend/admin/src/components/tabs/SpecialHoursTab.jsx
@@ -77,6 +77,27 @@ export default function SpecialHoursTab({ selectedRestaurant }) {
   const handleSave = async () => {
     if (!selectedRestaurant) return;
 
+    // 유효성 검사
+    for (const h of specialHours) {
+      // 휴무인데 시간 입력된 경우
+      if (h.isClosed && (h.openTime || h.closeTime)) {
+        alert(`${h.specialDate} 은(는) 휴무일입니다. 시간을 비워주세요.`);
+        return;
+      }
+
+      // 운영일인데 시간 누락된 경우
+      if (!h.isClosed && (!h.openTime || !h.closeTime)) {
+        alert(`${h.specialDate} 의 오픈/마감 시간을 모두 입력해주세요.`);
+        return;
+      }
+
+      // 오픈시간이 마감시간보다 늦은 경우
+      if (!h.isClosed && h.openTime >= h.closeTime) {
+        alert(`${h.specialDate} 의 오픈시간이 마감시간보다 늦습니다.`);
+        return;
+      }
+    }
+
     const payload = specialHours.map((h) => ({
       ...h,
       openTime: h.isClosed ? null : h.openTime ? h.openTime + ":00" : null,
@@ -96,6 +117,7 @@ export default function SpecialHoursTab({ selectedRestaurant }) {
   };
 
 
+
   const totalPages = Math.ceil(specialHours.length / itemsPerPage);
   const currentItems = specialHours.slice(
     (currentPage - 1) * itemsPerPage,
@@ -103,17 +125,17 @@ export default function SpecialHoursTab({ selectedRestaurant }) {
   );
 
   if (!selectedRestaurant)
-  return (
-    <div className="tab-pane fade" id="special-hours">
-      <div className="card text-center mt-4 border-danger">
-        <div className="card-body py-5">
-          <i className="fas fa-store-slash fa-3x text-danger mb-3"></i>
-          <h5 className="text-danger fw-bold">매장이 선택되지 않았습니다</h5>
-          <p className="text-muted mb-0">특별 운영시간을 관리하려면 먼저 매장을 선택해주세요.</p>
+    return (
+      <div className="tab-pane fade" id="special-hours">
+        <div className="card text-center mt-4 border-danger">
+          <div className="card-body py-5">
+            <i className="fas fa-store-slash fa-3x text-danger mb-3"></i>
+            <h5 className="text-danger fw-bold">매장이 선택되지 않았습니다</h5>
+            <p className="text-muted mb-0">특별 운영시간을 관리하려면 먼저 매장을 선택해주세요.</p>
+          </div>
         </div>
       </div>
-    </div>
-  );
+    );
 
 
   return (


### PR DESCRIPTION
## 🔗 관련 이슈
TETO-97

## 📝 작업 내용
- 휴무일 표시 로직 오류 수정
- 정기휴무일이 정상적으로 표시되도록 수정
- 특별휴무일과의 우선순위 처리 보완

## 🔍 변경 이유
- 영업중임에도 ‘휴무일 없음’으로 잘못 표시되는 문제 발생
- 정기휴무일과 특별휴무일 로직 간 충돌 해결

## 💬 리뷰 포인트
- 정기휴무/특별휴무 우선 적용 로직 확인
- 정상 영업일 출력 및 메시지 표시 여부 검증
