### PR TITLE
TETO-110 Bugfix: Lazy 로딩 문제 수정

### DIFF
--- a/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/reservation/controller/TableSelectionController.java
+++ b/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/reservation/controller/TableSelectionController.java
@@ -19,6 +19,7 @@ import com.tabletopia.restaurantservice.domain.restaurantTable.service.Restauran
 import com.tabletopia.restaurantservice.domain.user.dto.UserInfoDTO;
 import com.tabletopia.restaurantservice.domain.user.service.UserService;
 import jakarta.servlet.http.HttpSession;
+import java.security.Principal;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;

--- a/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurantreview/entity/RestaurantReview.java
+++ b/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurantreview/entity/RestaurantReview.java
@@ -1,6 +1,6 @@
 package com.tabletopia.restaurantservice.domain.restaurantreview.entity;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.tabletopia.restaurantservice.domain.restaurant.entity.Restaurant;
 import com.tabletopia.restaurantservice.domain.user.entity.User;
 import jakarta.persistence.Column;
@@ -28,11 +28,12 @@ public class RestaurantReview {
   private Long id;
 
   @ManyToOne(fetch = FetchType.LAZY)
+  @JsonIgnore
   private User user;
 
   @ManyToOne(fetch = FetchType.LAZY)
   @JoinColumn(name = "restaurant_id", nullable = false)
-  @JsonIgnoreProperties({"hibernateLazyInitializer", "handler"})
+  @JsonIgnore
   private Restaurant restaurant;
 
   @Column(nullable = false)

--- a/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurantreview/repository/RestaurantReviewRepository.java
+++ b/backend/restaurant-service/src/main/java/com/tabletopia/restaurantservice/domain/restaurantreview/repository/RestaurantReviewRepository.java
@@ -4,7 +4,8 @@ import com.tabletopia.restaurantservice.domain.restaurant.entity.Restaurant;
 import com.tabletopia.restaurantservice.domain.restaurantreview.entity.RestaurantReview;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.w3c.dom.stylesheets.LinkStyle;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /**
  * 레스토랑 리뷰 리포지토리
@@ -15,11 +16,12 @@ import org.w3c.dom.stylesheets.LinkStyle;
 public interface RestaurantReviewRepository extends JpaRepository<RestaurantReview, Long> {
 
   /**
-   * 레스토랑의 리뷰 목록 조회
+   * 레스토랑의 리뷰 목록 조회 (User fetch join으로 N+1 문제 해결)
    * @author 김예진
    * @since 2025-10-16
    * @param restaurantId
    * @return
    */
-  List<RestaurantReview> getRestaurantReviewsByRestaurant_Id(Long restaurantId);
+  @Query("SELECT r FROM RestaurantReview r JOIN FETCH r.user WHERE r.restaurant.id = :restaurantId")
+  List<RestaurantReview> getRestaurantReviewsByRestaurant_Id(@Param("restaurantId") Long restaurantId);
 }

--- a/frontend/admin/src/components/tabs/ReviewsTab.jsx
+++ b/frontend/admin/src/components/tabs/ReviewsTab.jsx
@@ -14,7 +14,7 @@ export default function ReviewsTab({ selectedRestaurant }) {
     if (!selectedRestaurant) return
     setLoading(true)
     try {
-      const res = await axios.get(`http://localhost:8002/api/reviews/${selectedRestaurant.id}`)
+      const res = await axios.get(`http://localhost:8002/api/restaurants/${selectedRestaurant.id}/reviews`)
       setReviews(res.data)
     } catch (err) {
       console.error("리뷰 목록 로드 실패:", err)


### PR DESCRIPTION
<!-- 
제목 양식
Jira-키 커밋타입: 제목
ex, PROJ-3 Feature: JWT 기반 사용자 인증 시스템 구현
-->

## 🔗 관련 이슈
<!-- 연결된 깃허브 이슈 번호 작성 -->

## 📝 작업 내용
<!-- 이번 PR에서 구현/수정한 기능을 간단히 작성 -->
  2. 해결1 - Repository: @Query로 JOIN FETCH r.user 추가해서 User를 미리 로딩하도록 수정 (N+1 문제도 해결)
  3. 해결2 - Entity: RestaurantReview의 User와 Restaurant 필드에 @JsonIgnore 추가해서 엔티티가 실수로 직렬화되어도 Lazy 필드는 무시되도록 방어
  4. 해결3 - 설정: application.properties에 spring.jackson.serialization.fail-on-empty-beans=false 추가해서 빈 프록시 객체 직렬화 에러 방지

## 🔍 변경 이유
<!-- 왜 이 변경이 필요한지 간단히 작성 -->
  1. 문제: RestaurantReview 엔티티에서 User를 FetchType.LAZY로 설정했는데, DTO 변환 시 review.getUser().getName() 호출하면서 Hibernate 프록시 객체가 JSON 직렬화되어 ByteBuddyInterceptor 에러 발생


## 💬 리뷰 포인트
<!-- 리뷰어가 집중해서 확인해야 할 사항 -->
